### PR TITLE
Change behavior of AnimalEmotionCore parameters keeping them > 0

### DIFF
--- a/examples/AnimalEmotionCore/main.cpp
+++ b/examples/AnimalEmotionCore/main.cpp
@@ -53,7 +53,7 @@ int main() {
             .weights     = {
                     {.core_param_name = "adrenaline", .weight = 0.3},
                     {.core_param_name = "cortisol", .weight = 0.3},
-                    {.core_param_name = "dopamine", .weight = -0.3},
+                    {.core_param_name = "dopamine", .weight = -2},
             }};
     core.AddSensorDataDescriptor(light_sensor);
     core.AddSensorDataDescriptor(proximity);

--- a/include/AnimalEmotionCore/AnimalEmotionCore.hpp
+++ b/include/AnimalEmotionCore/AnimalEmotionCore.hpp
@@ -26,12 +26,9 @@
 #include "GenericEmotionCore/GenericEmotionCore.hpp"
 
 class AnimalEmotionCore : private GenericEmotionCore {
-private:
-    using GenericEmotionCore::UpdateCoreParamsFromSensorData;
-    using GenericEmotionCore::UpdateCoreParamsWithTimeUpdate;
-    using GenericEmotionCore::UpdateCurrentEmotionalState;
+protected:
     using GenericEmotionCore::UpdateParamsTotal;
-
+    emotion_core_err_t UpdateParamsTotal();
 public:
     AnimalEmotionCore();
     using GenericEmotionCore::time_ms;

--- a/include/GenericEmotionCore/GenericEmotionCore.hpp
+++ b/include/GenericEmotionCore/GenericEmotionCore.hpp
@@ -32,7 +32,8 @@
 #include "GenericEmotionCore/emotion_core_err_t.h"
 
 class GenericEmotionCore {
-private:
+protected:
+
     const EmotionalStateDescriptorStruct_t *_EmotionalState_p;  ///< NULL means - non-specified state
 
     EmotionalStateDescriptorStruct_t _non_specified_state;  // FIXME bad idea, do it better
@@ -61,7 +62,6 @@ private:
 
     emotion_core_err_t SetState(const EmotionalStateDescriptorStruct_t *state);
 
-protected:
 public:
     GenericEmotionCore();
 
@@ -83,7 +83,7 @@ public:
     */
     emotion_core_err_t UpdateCurrentEmotionalState();
 
-    emotion_core_err_t UpdateParamsTotal();
+    virtual emotion_core_err_t UpdateParamsTotal();
 
     emotion_core_err_t UpdateCoreParamsFromSensorData(const SensorDataStruct_t &data);
 

--- a/src/AnimalEmotionCore/AnimalEmotionCore.cpp
+++ b/src/AnimalEmotionCore/AnimalEmotionCore.cpp
@@ -48,3 +48,22 @@ AnimalEmotionCore::AnimalEmotionCore() {
     UpdateParamsTotal();
     UpdateCurrentEmotionalState();
 }
+
+
+emotion_core_err_t AnimalEmotionCore::UpdateParamsTotal() {
+    float val;
+    for (auto i = _params_base.GetParams()->begin(); i != _params_base.GetParams()->end(); i++) {
+        val = _params_base.GetParam(i->first);
+        val += _params_sensorsImpacts.GetParam(i->first);
+        for (auto i_tmp = _params_tempImpacts.begin(); i_tmp != _params_tempImpacts.end(); i_tmp++) {
+            if (i_tmp->param_name == i->first) {
+                val += i_tmp->delta_value;
+            }
+        }
+        if (val < 0) {
+            val = 0;
+        }
+        RETURN_ON_ERROR(_params_total.SetParam(i->first, val));
+    }
+    return NO_ERROR;
+}


### PR DESCRIPTION
... because the parameters represent the matter that can only exist and do not exist